### PR TITLE
Allow passing in original size to support large images on android

### DIFF
--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -23,7 +23,18 @@ class ImgManipulator extends Component {
             uri: photo.uri,
         }
 
-        this.scrollOffset = 0
+        this.scrollOffset = 0;
+
+        if(photo.width || photo.height){
+            this.trueSize = {}
+            if(photo.width){
+                this.trueSize.width = photo.width;
+            }
+            if(photo.height){
+                this.trueSize.height = photo.height;
+            }
+        }
+        
 
         this.currentPos = {
             left: 0,
@@ -89,9 +100,9 @@ class ImgManipulator extends Component {
         let imgHeight
         // const { photo } = this.props
         const { uri } = this.state
-        Image.getSize(uri, (width2, height2) => {
-            imgWidth = width2
-            imgHeight = height2
+        Image.getSize(uri, (width2, height2) => {            
+            imgWidth = this.trueSize.width || width2;
+            imgHeight = this.trueSize.height || height2;
             const heightRatio = this.currentSize.height / this.maxSizes.height
             const offsetHeightRatio = this.currentPos.top / this.maxSizes.height
 
@@ -193,8 +204,8 @@ class ImgManipulator extends Component {
                     rotate: -90,
                 }, {
                     resize: {
-                        width: height2,
-                        height: width2,
+                        width: this.trueSize.height || height2,
+                        height: this.trueSize.width || width2,
                     },
                 }], {
                     compress: 1,
@@ -213,8 +224,8 @@ class ImgManipulator extends Component {
                         rotate: -90,
                     }, {
                         resize: {
-                            width: height2,
-                            height: width2,
+                            width: this.trueSize.height || height2,
+                            height: this.trueSize.width || width2,
                         },
                     }], {
                         compress: 1,

--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -15,6 +15,12 @@ import HybridTouch from '../HybridTouch'
 const { width } = Dimensions.get('window')
 
 class ImgManipulator extends Component {
+    get trueWidth() {
+        return this.trueSize && this.trueSize.width ? this.trueSize.width : null;
+    }
+    get trueHeight() {
+        return this.trueSize && this.trueSize.height ? this.trueSize.height : null;
+    }
     constructor(props) {
         super(props)
         const { photo } = this.props
@@ -25,16 +31,15 @@ class ImgManipulator extends Component {
 
         this.scrollOffset = 0;
 
-        if(photo.width || photo.height){
-            this.trueSize = {}
-            if(photo.width){
+        this.trueSize = {};
+        if (photo.width || photo.height) {
+            if (photo.width) {
                 this.trueSize.width = photo.width;
             }
-            if(photo.height){
+            if (photo.height) {
                 this.trueSize.height = photo.height;
             }
         }
-        
 
         this.currentPos = {
             left: 0,
@@ -101,8 +106,8 @@ class ImgManipulator extends Component {
         // const { photo } = this.props
         const { uri } = this.state
         Image.getSize(uri, (width2, height2) => {            
-            imgWidth = this.trueSize.width || width2;
-            imgHeight = this.trueSize.height || height2;
+            imgWidth = this.trueWidth || width2;
+            imgHeight = this.trueHeight || height2;
             const heightRatio = this.currentSize.height / this.maxSizes.height
             const offsetHeightRatio = this.currentPos.top / this.maxSizes.height
 
@@ -204,8 +209,8 @@ class ImgManipulator extends Component {
                     rotate: -90,
                 }, {
                     resize: {
-                        width: this.trueSize.height || height2,
-                        height: this.trueSize.width || width2,
+                          width: this.trueWidth || width2,
+                          height: this.trueHeight || height2,
                     },
                 }], {
                     compress: 1,
@@ -224,8 +229,8 @@ class ImgManipulator extends Component {
                         rotate: -90,
                     }, {
                         resize: {
-                            width: this.trueSize.height || height2,
-                            height: this.trueSize.width || width2,
+                             width: this.trueWidth || width2,
+                             height: this.trueHeight || height2,
                         },
                     }], {
                         compress: 1,


### PR DESCRIPTION
Image.getSize will return the modified size not the original when choosing large images on android.
More details here : https://github.com/facebook/react-native/issues/22145

This resulted in Android cropping incorrectly because the image was downsized for the selection of the crop, but the original was used for the actual crop.

This fix allows developers to pass in the original height and/or width of the image along with the URI, and then uses that height and width when performing manipulations (if it was provided).

If no height or width is provided with the uri then Image.getSize dimensions are still used (making this backwards compatible). 