### PR TITLE
can disable zooming

### DIFF
--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -235,6 +235,7 @@ class ImgManipulator extends Component {
             onPictureChoosed,
             borderColor = 'yellow',
             allowRotate = true,
+            pinchGestureEnabled,
         } = this.props
         const {
             uri,
@@ -289,6 +290,7 @@ class ImgManipulator extends Component {
                         bounces={false}
                         ref={(c) => { this.scrollView = c }}
                         scrollEventThrottle={16}
+                        pinchGestureEnabled={pinchGestureEnabled}
                     >
                         <AutoHeightImage
                             style={{ backgroundColor: 'black' }}


### PR DESCRIPTION
If a user zooms out and then tried to crop the crop rectangle starts behaving oddly and often won't resize.  I couldn't find the source of this odd behavior, it appears to be a side effect of the image size being different than the original dimensions.

I don't need image zooming, so I'm adding a way to pass through the `pinchGestureEnabled` prop onto the scrollview.