### PR TITLE
allow user to define accepted photo save option

### DIFF
--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -76,7 +76,7 @@ class ExpoImageManipulator extends Component {
     }
 
     async onConvertImageToEditableSize() {
-        const { photo: { uri: rawUri }, acceptedImageSaveOption } = this.props
+        const { photo: { uri: rawUri }, saveOptions } = this.props
         Image.getSize(rawUri, async (imgW, imgH) => {
             const { convertedWidth, convertedheight } = this.onGetCorrectSizes(imgW, imgH)
             const { uri, width: w, height } = await ImageManipulator.manipulateAsync(rawUri,
@@ -87,7 +87,7 @@ class ExpoImageManipulator extends Component {
                             height: convertedheight,
                         },
                     },
-                ], acceptedImageSaveOption)
+                ], saveOptions)
             this.setState({
                 uri,
             })
@@ -505,11 +505,6 @@ ExpoImageManipulator.defaultProps = {
         base64: false,
     },
     fixedMask: null,
-    acceptedImageSaveOption: {
-        compress: 1,
-        format: ImageManipulator.SaveFormat.PNG,
-        base64: false,
-    },
 }
 
 ExpoImageManipulator.propTypes = {
@@ -522,5 +517,4 @@ ExpoImageManipulator.propTypes = {
     photo: PropTypes.object.isRequired,
     onToggleModal: PropTypes.func.isRequired,
     ratio: PropTypes.object,
-    acceptedImageSaveOption: PropTypes.object,
 }

--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -76,7 +76,7 @@ class ExpoImageManipulator extends Component {
     }
 
     async onConvertImageToEditableSize() {
-        const { photo: { uri: rawUri } } = this.props
+        const { photo: { uri: rawUri }, acceptedImageSaveOption } = this.props
         Image.getSize(rawUri, async (imgW, imgH) => {
             const { convertedWidth, convertedheight } = this.onGetCorrectSizes(imgW, imgH)
             const { uri, width: w, height } = await ImageManipulator.manipulateAsync(rawUri,
@@ -87,7 +87,7 @@ class ExpoImageManipulator extends Component {
                             height: convertedheight,
                         },
                     },
-                ])
+                ], acceptedImageSaveOption)
             this.setState({
                 uri,
             })
@@ -505,6 +505,11 @@ ExpoImageManipulator.defaultProps = {
         base64: false,
     },
     fixedMask: null,
+    acceptedImageSaveOption: {
+        compress: 1,
+        format: ImageManipulator.SaveFormat.PNG,
+        base64: false,
+    },
 }
 
 ExpoImageManipulator.propTypes = {
@@ -517,4 +522,5 @@ ExpoImageManipulator.propTypes = {
     photo: PropTypes.object.isRequired,
     onToggleModal: PropTypes.func.isRequired,
     ratio: PropTypes.object,
+    acceptedImageSaveOption: PropTypes.object,
 }


### PR DESCRIPTION
I added a saveOption props to income photo props for generating image format from it.

when the user uploads a .png image with transparent background, you will see that a transparent background converts into a white background in the final image.

So with that change, I fix this issue.


