### PR TITLE
Align image to center to fix android crop issue

### DIFF
--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -440,7 +440,7 @@ class ExpoImageManipulator extends Component {
                 <View style={{ flex: 1, backgroundColor: 'black', width: Dimensions.get('window').width }}>
                     <ScrollView
                         style={{ position: 'relative', flex: 1 }}
-                        contentContainerStyle={{ backgroundColor: 'black' }}
+                        contentContainerStyle={{ backgroundColor: 'black', flex: 1, justifyContent: 'center' }}
                         maximumZoomScale={5}
                         minimumZoomScale={0.5}
                         onScroll={this.onHandleScroll}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-image-crop",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Crop, rotate and flip images without detach your expo project!",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Crop does not work correctly in android. To fix this, the images are aligned to center. 

The issue is demonstrated with the following screenshots
![Screenshot_20220412-131530_Expo Go](https://user-images.githubusercontent.com/6150713/162947720-02e49e23-b93c-466e-af78-a80f997ac98c.jpg)|![Screenshot_20220412-132103_Expo Go](https://user-images.githubusercontent.com/6150713/162947745-1212f6e3-3334-4e35-b0ce-66bf6d004e06.jpg)|![Screenshot_20220412-132110_Expo Go](https://user-images.githubusercontent.com/6150713/162947766-faba2ec2-335f-490f-92e6-6c1fcf6944db.jpg)
